### PR TITLE
Update main_slim.css

### DIFF
--- a/conreq/core/base/static/css/main_slim.css
+++ b/conreq/core/base/static/css/main_slim.css
@@ -55,6 +55,7 @@ body,
 	overflow-y: auto;
 	-webkit-backdrop-filter: blur(10px);
 	backdrop-filter: blur(10px);
+	z-index: 1;
 }
 
 .logo {


### PR DESCRIPTION
Include z-index: 1; to .default-box to fix z-index stacking on Firefox for the login screen text boxes.