### PR TITLE
Bump python version to fix test suite

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -12,7 +12,7 @@ jobs:
         strategy:
             max-parallel: 4
             matrix:
-                python-version: [3.9]
+                python-version: [3.11]
 
         steps:
             - uses: actions/checkout@v2


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the CI workflow configuration to use Python 3.11, aiming to fix issues in the test suite.

- **CI**:
    - Updated the CI workflow to use Python 3.11 instead of Python 3.9.

<!-- Generated by sourcery-ai[bot]: end summary -->